### PR TITLE
Fix error reporting in Cyclone custom bare

### DIFF
--- a/static/customBare.mjs
+++ b/static/customBare.mjs
@@ -90,11 +90,10 @@ async function fetchBare(url, res, req) {
             request.body.pipe(res)
         }
     } catch (e) {
-        console.log(e);
         res.writeHead(500, 'Error', {
             'content-type': 'application/javascript'
         })
-        res.end(e);
+        res.end(e.stack);
     }
 }
 

--- a/static/customBare.mjs
+++ b/static/customBare.mjs
@@ -45,9 +45,9 @@ async function fetchBare(url, res, req) {
         var options = {
             method: req.method,
             headers: {
-                "Refer": url.href,
-                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.63 Safari/537.36",
-                "cookies": req.cookies,
+                "Referer": url.href,
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.63 Safari/537.36",
+                "Cookie": req.headers.cookie,
             },
         }
 


### PR DESCRIPTION
console.log(e) is a bad idea in general. Moreover, errors cannot be
written to streams, since they are neither strings nor Buffers.