### PR TITLE
More error-handling fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,4 +44,12 @@ server.on('upgrade', (req, socket, head) => {
 
 server.listen(PORT);
 
+if (process.env.UNSAFE_CONTINUE)
+  process.on("uncaughtException", (err, origin) => {
+    console.error(`Critical error (${origin}):`)
+    console.error(err)
+    console.error("UNSAFELY CONTINUING EXECUTION")
+    console.error()
+  })
+
 console.log(`Server running at http://localhost:${PORT}/.`);

--- a/app.js
+++ b/app.js
@@ -19,12 +19,19 @@ const serve = new nodeStatic.Server(join(
 const server = http.createServer();
 
 server.on('request', (request, response) => {
-  if (custombare.route(request, response)) return true;
-  
-  if (bareServer.shouldRoute(request)) {
-    bareServer.routeRequest(request, response);
-  } else {
-    serve.serve(request, response);
+  try {
+    if (custombare.route(request, response)) return true;
+
+    if (bareServer.shouldRoute(request)) {
+      bareServer.routeRequest(request, response);
+    } else {
+      serve.serve(request, response);
+    }
+  } catch (e) {
+    response.writeHead(500, "Internal Server Error", {
+      "Content-Type": "text/plain"
+    })
+    response.end(e.stack)
   }
 });
 server.on('upgrade', (req, socket, head) => {

--- a/static/customBare.mjs
+++ b/static/customBare.mjs
@@ -82,8 +82,8 @@ async function fetchBare(url, res, req) {
             request.body.pipe(res)
         }
     } catch (e) {
-        res.writeHead(500, 'Error', {
-            'content-type': 'application/javascript'
+        res.writeHead(500, 'Internal Server Error', {
+            'Content-Type': 'text/plain'
         })
         res.end(e.stack);
     }

--- a/static/customBare.mjs
+++ b/static/customBare.mjs
@@ -51,15 +51,7 @@ async function fetchBare(url, res, req) {
             },
         }
 
-        try {
-            var request = await fetch(url.href, options);
-        } catch (e) {
-            var request = {
-                text() {
-                    return 'Error: ' + e;
-                },
-            }
-        }
+        var request = await fetch(url.href, options);
 
         try {
             var contentType = request.headers.get('content-type') || 'application/javascript'


### PR DESCRIPTION
The most interesting change is as follows: if you run Nebula with `UNSAFE_CONTINUE=1 npm start`, any uncaught errors will not cause the server to crash. `1` can be replaced with any non-empty string.

This environment variable is required so you understand that [this behavior is inherently unsafe](https://nodejs.org/api/process.html#warning-using-uncaughtexception-correctly).