### PR TITLE
Clean up dependencies and license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,33 +7,33 @@
         "": {
             "name": "nebula-web",
             "version": "7.10.0",
-            "license": "GNU AGPL V3",
+            "license": "AGPL-3.0-only",
             "dependencies": {
-                "@tomphttp/bare-server-node": "^1.0.2-beta-readme5",
-                "crypto-js": "4.1.1",
-                "css-tree": "^2.1.0",
-                "node-fetch": "^3.2.6",
+                "@tomphttp/bare-server-node": "^1.2.2",
                 "nodemailer": "^6.8.0",
                 "nodemailer-sendgrid-transport": "^0.2.0",
-                "serve-static": "^1.15.0",
-                "ws": "^8.8.1"
+                "serve-static": "^1.15.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@tomphttp/bare-server-node": {
-            "version": "1.0.2-beta-readme5",
-            "resolved": "https://registry.npmjs.org/@tomphttp/bare-server-node/-/bare-server-node-1.0.2-beta-readme5.tgz",
-            "integrity": "sha512-WOYNae3faSj9Yt4dKVqzjbh1ovpKRhsevnJaM2BgC6LkRULFN/GhtslXDXG6KLbqeokFFj0XqpZ8TTzdxKyhkw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@tomphttp/bare-server-node/-/bare-server-node-1.2.2.tgz",
+            "integrity": "sha512-iaH2SiznLjc6vqHZd9/33ec3P+0u7kWHuK1BQ/hOE+E09MdYrlO2H8Tu8vS2Ha665OvsYjKNpF1G/j8cGNW3oA==",
             "dependencies": {
-                "commander": "^9.0.0",
-                "dotenv": "^16.0.1",
-                "fetch-headers": "^3.0.1",
-                "http-errors": "^2.0.0"
+                "commander": "^9.4.1",
+                "dotenv": "^16.0.3",
+                "headers-polyfill": "3.0.9",
+                "http-errors": "^2.0.0",
+                "source-map-support": "^0.5.21"
             },
             "bin": {
-                "bare-server-node": "scripts/start.js"
+                "bare-server-node": "bin.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@types/node": {
@@ -246,6 +246,11 @@
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+        },
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -335,11 +340,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
         },
-        "node_modules/crypto-js": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-        },
         "node_modules/css-select": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -349,19 +349,6 @@
                 "css-what": "2.1",
                 "domutils": "1.5.1",
                 "nth-check": "~1.0.1"
-            }
-        },
-        "node_modules/css-tree": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-            "dependencies": {
-                "mdn-data": "2.0.28",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-                "npm": ">=7.0.0"
             }
         },
         "node_modules/css-what": {
@@ -396,14 +383,6 @@
             },
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/data-uri-to-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-            "engines": {
-                "node": ">= 12"
             }
         },
         "node_modules/debug": {
@@ -689,46 +668,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "optional": true
         },
-        "node_modules/fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
-        "node_modules/fetch-headers": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fetch-headers/-/fetch-headers-3.0.1.tgz",
-            "integrity": "sha512-Kq+NyED/wLgT29St7aW47gAWg8EmmE5QmhwQ5RmPRULYLqpglA7Kc/ZnbqXu2vhH6mw1koikew2g94WiHLPmpA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "engines": {
-                "node": ">=12.20"
-            }
-        },
         "node_modules/forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -748,17 +687,6 @@
             },
             "engines": {
                 "node": ">= 0.12"
-            }
-        },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
             }
         },
         "node_modules/fresh": {
@@ -831,6 +759,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/headers-polyfill": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.9.tgz",
+            "integrity": "sha512-FFIXpxbA9HZJXofXqS4IBRa7Z8F1Y+/DwxHSEOOTswZxym8Kz+f6DNhrtnCRcjWcTN7LjjbE5stz0UnoUPNprQ=="
         },
         "node_modules/htmlparser2": {
             "version": "3.10.1",
@@ -1115,11 +1048,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/mdn-data": {
-            "version": "2.0.28",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
-        },
         "node_modules/mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -1159,41 +1087,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "3.2.10",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-            "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
-            }
         },
         "node_modules/nodemailer": {
             "version": "6.8.0",
@@ -1486,10 +1379,19 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1685,14 +1587,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/webidl-conversions": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
@@ -1717,26 +1611,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/ws": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-            "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/xml-name-validator": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
@@ -1746,14 +1620,15 @@
     },
     "dependencies": {
         "@tomphttp/bare-server-node": {
-            "version": "1.0.2-beta-readme5",
-            "resolved": "https://registry.npmjs.org/@tomphttp/bare-server-node/-/bare-server-node-1.0.2-beta-readme5.tgz",
-            "integrity": "sha512-WOYNae3faSj9Yt4dKVqzjbh1ovpKRhsevnJaM2BgC6LkRULFN/GhtslXDXG6KLbqeokFFj0XqpZ8TTzdxKyhkw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@tomphttp/bare-server-node/-/bare-server-node-1.2.2.tgz",
+            "integrity": "sha512-iaH2SiznLjc6vqHZd9/33ec3P+0u7kWHuK1BQ/hOE+E09MdYrlO2H8Tu8vS2Ha665OvsYjKNpF1G/j8cGNW3oA==",
             "requires": {
-                "commander": "^9.0.0",
-                "dotenv": "^16.0.1",
-                "fetch-headers": "^3.0.1",
-                "http-errors": "^2.0.0"
+                "commander": "^9.4.1",
+                "dotenv": "^16.0.3",
+                "headers-polyfill": "3.0.9",
+                "http-errors": "^2.0.0",
+                "source-map-support": "^0.5.21"
             }
         },
         "@types/node": {
@@ -1944,6 +1819,11 @@
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
+        "buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+        },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -2018,11 +1898,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
         },
-        "crypto-js": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-        },
         "css-select": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2032,15 +1907,6 @@
                 "css-what": "2.1",
                 "domutils": "1.5.1",
                 "nth-check": "~1.0.1"
-            }
-        },
-        "css-tree": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-            "requires": {
-                "mdn-data": "2.0.28",
-                "source-map-js": "^1.0.1"
             }
         },
         "css-what": {
@@ -2070,11 +1936,6 @@
             "requires": {
                 "assert-plus": "^1.0.0"
             }
-        },
-        "data-uri-to-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
         },
         "debug": {
             "version": "2.6.9",
@@ -2295,20 +2156,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "optional": true
         },
-        "fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "requires": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            }
-        },
-        "fetch-headers": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fetch-headers/-/fetch-headers-3.0.1.tgz",
-            "integrity": "sha512-Kq+NyED/wLgT29St7aW47gAWg8EmmE5QmhwQ5RmPRULYLqpglA7Kc/ZnbqXu2vhH6mw1koikew2g94WiHLPmpA=="
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2322,14 +2169,6 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
-            }
-        },
-        "formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "requires": {
-                "fetch-blob": "^3.1.2"
             }
         },
         "fresh": {
@@ -2386,6 +2225,11 @@
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
+        },
+        "headers-polyfill": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.9.tgz",
+            "integrity": "sha512-FFIXpxbA9HZJXofXqS4IBRa7Z8F1Y+/DwxHSEOOTswZxym8Kz+f6DNhrtnCRcjWcTN7LjjbE5stz0UnoUPNprQ=="
         },
         "htmlparser2": {
             "version": "3.10.1",
@@ -2640,11 +2484,6 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
             "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
         },
-        "mdn-data": {
-            "version": "2.0.28",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
-        },
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -2672,21 +2511,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-        },
-        "node-fetch": {
-            "version": "3.2.10",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-            "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
-            "requires": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            }
         },
         "nodemailer": {
             "version": "6.8.0",
@@ -2915,10 +2739,21 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         },
-        "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+        "source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
         },
         "sshpk": {
             "version": "1.17.0",
@@ -3063,11 +2898,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "web-streams-polyfill": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
-        },
         "webidl-conversions": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
@@ -3088,12 +2918,6 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "optional": true
-        },
-        "ws": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-            "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-            "requires": {}
         },
         "xml-name-validator": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,12 @@
         "proxy"
     ],
     "author": "Nebula Services",
-    "license": "GNU AGPL V3",
+    "license": "AGPL-3.0-only",
     "dependencies": {
-        "@tomphttp/bare-server-node": "^1.0.2-beta-readme5",
-        "crypto-js": "4.1.1",
-        "css-tree": "^2.1.0",
-        "node-fetch": "^3.2.6",
+        "@tomphttp/bare-server-node": "^1.2.2",
         "nodemailer": "^6.8.0",
         "nodemailer-sendgrid-transport": "^0.2.0",
-        "serve-static": "^1.15.0",
-        "ws": "^8.8.1"
+        "serve-static": "^1.15.0"
     },
     "engines": {
         "node": ">=16.0.0"


### PR DESCRIPTION
The license field in package.json now uses a valid SPDX identifier. Once again, you are not supposed to insert whatever string you want. This is the second time I made a change like this. The first time was commit a83063cf10ffb95319b14379fe7a94c296c45f9f.

This commit also removes unnecessary dependencies from the Cyclone era and bumps the versions of those that remain.