### PR TITLE
CVE-2022-2309

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20.4-bookworm-slim
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install


### PR DESCRIPTION
fixes old node version in docker setup which is vulnerable to [this CVE publication](https://www.cve.org/CVERecord?id=CVE-2022-2309)

Introduced through: node@18 -> libxml2@2.9.14+dfsg-1.2
Fix: Upgrade to libxml2@2.9.14+dfsg-1.3~deb12u1 <- node:20.4-bookworm-slim